### PR TITLE
fix: disconnect input tensors from upstream producers during mid-graph extraction

### DIFF
--- a/sne4onnx/onnx_network_extraction.py
+++ b/sne4onnx/onnx_network_extraction.py
@@ -199,6 +199,16 @@ def extraction(
                 input_tmp.append(graph_node_input)
     graph.inputs = input_tmp
 
+    # Disconnect input tensors from their producer nodes
+    # so that upstream nodes are properly removed during cleanup
+    for inp_tensor in input_tmp:
+        for producer_node in list(inp_tensor.inputs):
+            if hasattr(producer_node, 'outputs'):
+                producer_node.outputs = [
+                    t for t in producer_node.outputs if t is not inp_tensor
+                ]
+        inp_tensor.inputs.clear()
+
     graph.outputs = [
         graph_node_output \
             for graph_node in graph_node_outputs \

--- a/tests/generate_test_model.py
+++ b/tests/generate_test_model.py
@@ -1,0 +1,38 @@
+"""Generate a small ONNX model for testing mid-graph tensor extraction.
+
+Model structure:
+  input 'a' [1,4] -> Relu -> output 'b' [1,4] -> Add(b, const) -> output 'c' [1,4] -> Sigmoid -> output 'd' [1,4]
+
+Test scenario: extract sub-graph with input='b', output='d'
+Expected: extracted model starts at 'b', does not contain the Relu node that produces 'b'.
+"""
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+def generate_test_model(output_path: str = "tests/test_mid_graph_extraction.onnx"):
+    # Nodes: a -> Relu -> b -> Add(b, ones) -> c -> Sigmoid -> d
+    a = helper.make_tensor_value_info("a", TensorProto.FLOAT, [1, 4])
+    d = helper.make_tensor_value_info("d", TensorProto.FLOAT, [1, 4])
+
+    ones = helper.make_tensor("ones", TensorProto.FLOAT, [1, 4], np.ones([1, 4]).flatten().tolist())
+
+    relu_node = helper.make_node("Relu", inputs=["a"], outputs=["b"], name="Relu_0")
+    add_node = helper.make_node("Add", inputs=["b", "ones"], outputs=["c"], name="Add_1")
+    sigmoid_node = helper.make_node("Sigmoid", inputs=["c"], outputs=["d"], name="Sigmoid_2")
+
+    graph = helper.make_graph(
+        [relu_node, add_node, sigmoid_node],
+        "test_mid_graph",
+        [a],
+        [d],
+        initializer=[ones],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model = onnx.shape_inference.infer_shapes(model)
+    onnx.checker.check_model(model)
+    onnx.save(model, output_path)
+    print(f"Saved test model to {output_path}")
+
+if __name__ == "__main__":
+    generate_test_model()

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import pytest
+import onnx
+
+sys.path.insert(0, os.path.dirname(__file__))
+from generate_test_model import generate_test_model
+from sne4onnx import extraction
+
+TEST_MODEL_PATH = "tests/test_mid_graph_extraction.onnx"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_model():
+    generate_test_model(TEST_MODEL_PATH)
+
+
+class TestMidGraphExtraction:
+    """Test extracting a sub-graph where the specified input is a mid-graph tensor."""
+
+    def test_input_is_specified_tensor(self):
+        """Extracted model input should be 'b', not original input 'a'."""
+        model = extraction(
+            input_op_names=["b"],
+            output_op_names=["d"],
+            input_onnx_file_path=TEST_MODEL_PATH,
+            non_verbose=True,
+        )
+        input_names = [inp.name for inp in model.graph.input]
+        assert input_names == ["b"]
+
+    def test_upstream_nodes_removed(self):
+        """Relu_0 (which produces 'b' from 'a') should not be in the extracted model."""
+        model = extraction(
+            input_op_names=["b"],
+            output_op_names=["d"],
+            input_onnx_file_path=TEST_MODEL_PATH,
+            non_verbose=True,
+        )
+        node_names = [n.name for n in model.graph.node]
+        assert "Relu_0" not in node_names
+        # Original input 'a' should not appear anywhere
+        for node in model.graph.node:
+            assert "a" not in list(node.input)
+
+    def test_downstream_nodes_preserved(self):
+        """Add_1 and Sigmoid_2 should remain in the extracted model."""
+        model = extraction(
+            input_op_names=["b"],
+            output_op_names=["d"],
+            input_onnx_file_path=TEST_MODEL_PATH,
+            non_verbose=True,
+        )
+        node_names = [n.name for n in model.graph.node]
+        assert "Add_1" in node_names
+        assert "Sigmoid_2" in node_names
+
+    def test_output_is_correct(self):
+        """Extracted model output should be 'd'."""
+        model = extraction(
+            input_op_names=["b"],
+            output_op_names=["d"],
+            input_onnx_file_path=TEST_MODEL_PATH,
+            non_verbose=True,
+        )
+        output_names = [out.name for out in model.graph.output]
+        assert output_names == ["d"]
+
+    def test_passes_onnx_checker(self):
+        """Extracted model should be valid ONNX."""
+        model = extraction(
+            input_op_names=["b"],
+            output_op_names=["d"],
+            input_onnx_file_path=TEST_MODEL_PATH,
+            non_verbose=True,
+        )
+        onnx.checker.check_model(model)


### PR DESCRIPTION

When extracting a sub-graph with a mid-graph tensor as input, upstream nodes were incorrectly retained because _rebuild_edges() restored the producer relationship. Fix by removing the input tensor from its producer node's outputs list before cleanup.

Added unit tests with a generated abstract model to cover this scenario.